### PR TITLE
Add twitter_username config option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ tagline:          'Your World in One Place'
 description:      'Your World in One Place'
 url:              http://blog.dashboardhub.io
 baseurl:          /
+twitter_username: 'dashboardhub'
 
 author:
   name:           'Eddie Jaoude'


### PR DESCRIPTION
This should fix the "Share on Twitter" missing the "via" value (I think)
